### PR TITLE
Point to the small model

### DIFF
--- a/commitcanvas/__main__.py
+++ b/commitcanvas/__main__.py
@@ -22,8 +22,12 @@ def entry(path: str = None, commit: str = ".git/COMMIT_EDITMSG"):
     """Get commit message from command line and do checks."""
     commit_msg_filepath = commit
     # commitcanvas_check.commit_check(commit_msg_filepath)
-    stats = check_output(["git", "diff", "--staged", "--shortstat"]).strip()
-    file_names = check_output(["git", "diff", "--staged", "--name-only"]).strip()
+    stats = check_output(
+        ["git", "--no-pager", "diff", "--staged", "--shortstat"]
+    ).strip()
+    file_names = check_output(
+        ["git", "--no-pager", "diff", "--staged", "--name-only"]
+    ).strip()
 
     with open(commit_msg_filepath, "r+") as file:
         content = file.read()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ nltk = "^3.6.2"
 scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
-model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.1.1/model-0.1.0.tar.gz"}
+model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model-0.2.0.tar.gz"}
 reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "repo-mining" }
 commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
 model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model-0.2.0.tar.gz"}
-reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "main"}
-commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
+reporover = { git = "https://github.com/CommittedTeam/RepoRover"}
+commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
 model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model_small-0.2.0.tar.gz"}
-reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "repo-mining" }
+reporover = { git = "https://github.com/CommittedTeam/RepoRover"}
 commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ nltk = "^3.6.2"
 scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
-model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.1.1/model-0.1.0.tar.gz"}
+model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model_small-0.2.0.tar.gz"}
 reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "repo-mining" }
 commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,8 +16,8 @@ scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
 model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model-0.2.0.tar.gz"}
-reporover = { git = "https://github.com/CommittedTeam/RepoRover"}
-commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models"}
+reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "main"}
+commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "main" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
 model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model_small-0.2.0.tar.gz"}
-reporover = { git = "https://github.com/CommittedTeam/RepoRover"}
+reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "main"}
 commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ nltk = "^3.6.2"
 scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
-model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model_small-0.2.0.tar.gz"}
+model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model-0.2.0.tar.gz"}
 reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "main"}
 commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,9 +15,9 @@ nltk = "^3.6.2"
 scikit-learn = "^0.24.2"
 pandas = "^1.2.4"
 # install the deployed model as a commitcanvas dependency
-model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.2.0/model-0.2.0.tar.gz"}
-reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "main"}
-commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "main" }
+model = {url = "https://github.com/CommittedTeam/commitcanvas-models/releases/download/0.1.1/model-0.1.0.tar.gz"}
+reporover = { git = "https://github.com/CommittedTeam/RepoRover", branch = "repo-mining" }
+commitcanvas_models = { git = "https://github.com/CommittedTeam/commitcanvas-models", branch = "commitcanvas-model" }
 
 [tool.poetry.dev-dependencies]
 pytest = "^5.3.5"


### PR DESCRIPTION
<!-- A short description can be included here -->
<!-- Please ensure that reviewers are assigned -->

## What is the current behavior?
Commitcanvas uses a large model that takes a long time to load
Commitcanvas errors if the user has a pager
<!-- You can link to an open issue here -->

## What is the new behavior if this PR is merged?
Now Commitcanvas points to the smaller model, trained on 34 repositories. And takes about 30 seconds to load and predict at the time of commit
## Type of change

Please describe the pull request as one of the following:

- [X] Bug fix
- [ ] Breaking change
- [ ] New feature
- [ ] Documentation update
- [ ] Other <!-- Please specify any helpful information below -->

### Other information

### This PR has:

- [X] Commit messages that are correctly formatted
- [X] Tests for newly introduced code
- [X] Docstrings for newly introduced code

#### Developers
@bagashvilit 
@<!-- Include your name, and @ any others responsible for these changes -->